### PR TITLE
report error status line for naive_verify_failed_network

### DIFF
--- a/lib/Net/OpenID/Consumer.pm
+++ b/lib/Net/OpenID/Consumer.pm
@@ -978,7 +978,7 @@ sub verified_identity {
 
         my $ua  = $self->ua;
         my $res = $ua->request($req);
-        return $self->_fail("naive_verify_failed_network")
+        return $self->_fail("naive_verify_failed_network", sprintf("%s returned %s", $req->uri, $res->status_line))
           unless $res && $res->is_success;
 
         my $content = $res->content;


### PR DESCRIPTION
We had an issue where the endpoint suddenly returned 301 which is really
cumbersome to debug if Net::OpenID::Consumer doesn't report the real
error message.