### PR TITLE
explictly require CGI

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,7 @@ JSON                = 0
 
 [Prereqs / TestRequires]
 Test::More          = 0
+CGI                 = 0
 
 [ExtraTests]
 ; [PodCoverageTests]


### PR DESCRIPTION
CGI is no longer a core module since perl 5.22